### PR TITLE
Fix dead Get Started link on homepage.

### DIFF
--- a/layouts/home.html
+++ b/layouts/home.html
@@ -3,7 +3,7 @@
   <p class="subheading">{{ .Params.subheading }}</p>
   <div class="actions">
     <a class="btn btn-primary" href="javascript:"><i data-lucide="circle-play"></i>Watch teaser</a>
-    <a class="btn" href="/docs/guides/what-is-ultimatexr">Get started</a>
+    <a class="btn" href="/docs/getting-started/what-is-ultimatexr">Get started</a>
   </div>
   <div class="additional-links">
     <p>Latest: {{ .Site.Params.latest_version }}</p>


### PR DESCRIPTION
The link to the get started button is dead. Redirected to the old guides page.