### PR TITLE
Redundant margin-bottom on home.css

### DIFF
--- a/assets/css/home.css
+++ b/assets/css/home.css
@@ -41,7 +41,6 @@ body.kind-home h1 {
   font-size: 36px;
   line-height: 45px;
   font-weight: 700;
-  margin-bottom: var(--uxr-el-vertical-margin);
   max-width: 720px;
   margin-left: auto;
   margin-right: auto;


### PR DESCRIPTION
This margin-bottom seems to be misplaced here.
I've removed it from the home page because it seemed redundant for both desktop and mobile devices.

![image](https://github.com/user-attachments/assets/0d8a9ede-302f-4b74-9422-fb2b359c5754)

If I happen to be incorrect, please do let me know!